### PR TITLE
Fix spelling in aws-transit-network-orchestrator-hub.template

### DIFF
--- a/deployment/aws-transit-network-orchestrator-hub.template
+++ b/deployment/aws-transit-network-orchestrator-hub.template
@@ -16,11 +16,11 @@ Description: (SO0058) - The AWS CloudFormation template (Hub) for deployment of 
 Parameters:
   Principals:
     Type: CommaDelimitedList
-    Description: AWS account numbers eg. 123456789012 (comma seperated) OR the ARN of an Organization to share TGW with the principals eg. arn:aws:organizations::<ORG_MASTER_ACCOUNT_ID>:organization/o-exampleorgid.
+    Description: AWS account numbers eg. 123456789012 (comma separated) OR the ARN of an Organization to share TGW with the principals eg. arn:aws:organizations::<ORG_MASTER_ACCOUNT_ID>:organization/o-exampleorgid.
 
   PrincipalType:
     Type: String
-    Description: Either provide list of accounts (comma seperated) or AWS Organizations ARN
+    Description: Either provide list of accounts (comma separated) or AWS Organizations ARN
     Default: 'List of Accounts'
     AllowedValues:
       - 'AWS Organization ARN'
@@ -210,9 +210,9 @@ Metadata:
       ExistingGlobalNetworkId:
         default: (Optional) Provide the existing global network id.
       ListOfCustomCidrBlocks:
-        default: If selected 'Custom-Destinations', provide a comma seperated list of CIDR Blocks.
+        default: If selected 'Custom-Destinations', provide a comma separated list of CIDR Blocks.
       CustomerManagedPrefixListIds:
-        default: If selected 'Custom-Destinations', provide a comma seperated list of Customer-managed Prefix List IDs.
+        default: If selected 'Custom-Destinations', provide a comma separated list of Customer-managed Prefix List IDs.
 
 
 Conditions:

--- a/source/ui/src/App.js
+++ b/source/ui/src/App.js
@@ -93,7 +93,7 @@ class App extends React.Component {
         <div>
           <nav className="topnav">
             <FontAwesomeIcon icon={faAws} size="2x" color="#FF9900" id="logo" />
-            <h1 > Transit Network Managment Console</h1>
+            <h1 > Transit Network Management Console</h1>
             <Link to="" onClick={this.signOut}>Sign Out</Link>
           </nav>
 


### PR DESCRIPTION
Fix spelling.

*Issue #, if available:*

*Description of changes:*

Fix spelling.

Might cause resource replacement depending on AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
