### PR TITLE
Show Spoke Account Name in both approval email and the stno dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules
 *sonarlint*
 docs
 test.sh
+.python-version

--- a/source/lambda/state_machine/state_machine_handler.py
+++ b/source/lambda/state_machine/state_machine_handler.py
@@ -2363,6 +2363,7 @@ class DynamoDb:
                 "Action": self.is_none(self.event.get("Action")),
                 "Status": self.is_none(self.event.get("Status")),
                 "AWSSpokeAccountId": self.is_none(self.event.get("account")),
+                "AWSAccountName": self.is_none(Organizations().get_account_name(self.event.get("account"))),
                 "UserId": "StateMachine"
                 if self.event.get("UserId") is None
                 else self.event.get("UserId"),
@@ -2411,6 +2412,7 @@ class ApprovalNotification:
         self.spoke_account_id = self.event.get("account")
         self.spoke_region = environ.get("AWS_REGION")
         self.assume_role = AssumeRole()
+        self.account_name = Organizations().get_account_name(self.spoke_account_id)
         self.logger.info(self.__class__.__name__ + CLASS_EVENT)
         self.logger.info(event)
 
@@ -2491,10 +2493,11 @@ class ApprovalNotification:
         topic_arn = environ.get("APPROVAL_NOTIFICATION_ARN")
         subject = "STNO: Transit Network Change Requested"
         message = (
-            "A new request for VPC: '{}' to associate with TGW Route Table: '{}' and propagate to "
+            "A new request for VPC: '{}' from account {} to associate with TGW Route Table: '{}' and propagate to "
             "TGW Route Tables: '{}' is ready for review. Please use this link {} to login to the 'Transit Network "
             "Management Console' to approve or reject the request.".format(
                 self.event.get("VpcId"),
+                self.account_name or "N/A",
                 self.event.get("Associate-with").title(),
                 ", ".join(self.event.get("Propagate-to")).title(),
                 environ.get("STNO_CONSOLE_LINK"),

--- a/source/lambda/state_machine/state_machine_handler.py
+++ b/source/lambda/state_machine/state_machine_handler.py
@@ -2363,7 +2363,7 @@ class DynamoDb:
                 "Action": self.is_none(self.event.get("Action")),
                 "Status": self.is_none(self.event.get("Status")),
                 "AWSSpokeAccountId": self.is_none(self.event.get("account")),
-                "AWSAccountName": self.is_none(Organizations().get_account_name(self.event.get("account"))),
+                "AWSSpokeAccountName": self.is_none(Organizations().get_account_name(self.event.get("account"))),
                 "UserId": "StateMachine"
                 if self.event.get("UserId") is None
                 else self.event.get("UserId"),

--- a/source/ui/src/Components/Action/Action.js
+++ b/source/ui/src/Components/Action/Action.js
@@ -61,7 +61,7 @@ class Action extends Component {
           TagEventSource: "",
           Action: "",
           AWSSpokeAccountId: "",
-          AWSAccountName:"",
+          AWSSpokeAccountName:"",
           TimeToLive: "",
           AvailabilityZone: "",
           VpcCidr: "",
@@ -113,8 +113,8 @@ class Action extends Component {
           field: "AWSSpokeAccountId",
         },
         {
-          headerName: "Account Name",
-          field: "AWSAccountName"
+          headerName: "Spoke Account Name",
+          field: "AWSSpokeAccountName"
         },
         {
           headerName: "Subnet Id",

--- a/source/ui/src/Components/Action/Action.js
+++ b/source/ui/src/Components/Action/Action.js
@@ -61,6 +61,7 @@ class Action extends Component {
           TagEventSource: "",
           Action: "",
           AWSSpokeAccountId: "",
+          AWSAccountName:"",
           TimeToLive: "",
           AvailabilityZone: "",
           VpcCidr: "",
@@ -110,6 +111,10 @@ class Action extends Component {
         {
           headerName: "Spoke Account",
           field: "AWSSpokeAccountId",
+        },
+        {
+          headerName: "Account Name",
+          field: "AWSAccountName"
         },
         {
           headerName: "Subnet Id",

--- a/source/ui/src/Components/Dashboard/Dashboard.js
+++ b/source/ui/src/Components/Dashboard/Dashboard.js
@@ -43,6 +43,7 @@ class Dashboard extends Component {
           TagEventSource: "",
           Action: "",
           AWSSpokeAccountId: "",
+          AWSAccountName:"",
           TimeToLive: "",
           AvailabilityZone: "",
           VpcCidr: "",
@@ -96,6 +97,10 @@ class Dashboard extends Component {
         {
           headerName: "Spoke Account",
           field: "AWSSpokeAccountId",
+        },
+        {
+          headerName: "Account Name",
+          field: "AWSAccountName",
         },
         {
           headerName: "Subnet Id",

--- a/source/ui/src/Components/Dashboard/Dashboard.js
+++ b/source/ui/src/Components/Dashboard/Dashboard.js
@@ -43,7 +43,7 @@ class Dashboard extends Component {
           TagEventSource: "",
           Action: "",
           AWSSpokeAccountId: "",
-          AWSAccountName:"",
+          AWSSpokeAccountName:"",
           TimeToLive: "",
           AvailabilityZone: "",
           VpcCidr: "",
@@ -99,8 +99,8 @@ class Dashboard extends Component {
           field: "AWSSpokeAccountId",
         },
         {
-          headerName: "Account Name",
-          field: "AWSAccountName",
+          headerName: "Spoke Account Name",
+          field: "AWSSpokeAccountName",
         },
         {
           headerName: "Subnet Id",

--- a/source/ui/src/graphql/queries.js
+++ b/source/ui/src/graphql/queries.js
@@ -13,7 +13,7 @@ export const getActionItemsFromTransitNetworkOrchestratorTables = `query GetActi
   ) {
     items {
       AWSSpokeAccountId
-      AWSAccountName
+      AWSSpokeAccountName
       Action
       AdminAction
       AvailabilityZone
@@ -48,7 +48,7 @@ export const getDashboardItemsFromTransitNetworkOrchestratorTables = `query getD
   ) {
     items {
       AWSSpokeAccountId
-      AWSAccountName
+      AWSSpokeAccountName
       Action
       AdminAction
       AvailabilityZone
@@ -83,6 +83,7 @@ export const getVersionHistoryForSubnetFromTransitNetworkOrchestratorTables = `q
   ) {
     items {
       AWSSpokeAccountId
+      AWSSpokeAccountName
       Action
       AdminAction
       AvailabilityZone

--- a/source/ui/src/graphql/queries.js
+++ b/source/ui/src/graphql/queries.js
@@ -13,6 +13,7 @@ export const getActionItemsFromTransitNetworkOrchestratorTables = `query GetActi
   ) {
     items {
       AWSSpokeAccountId
+      AWSAccountName
       Action
       AdminAction
       AvailabilityZone
@@ -47,6 +48,7 @@ export const getDashboardItemsFromTransitNetworkOrchestratorTables = `query getD
   ) {
     items {
       AWSSpokeAccountId
+      AWSAccountName
       Action
       AdminAction
       AvailabilityZone

--- a/source/ui/src/graphql/schema.graphql
+++ b/source/ui/src/graphql/schema.graphql
@@ -25,7 +25,7 @@ type TransitNetworkOrchestratorTableConnection {
 
 type TransitNetworkOrchestratorTableMoreFields {
   AWSSpokeAccountId: String
-  AWSAccountName: String
+  AWSSpokeAccountName: String
   Action: String
   AdminAction: String
   AvailabilityZone: String
@@ -47,7 +47,7 @@ type TransitNetworkOrchestratorTableMoreFields {
 
 type UpdateTransitNetworkOrchestratorTable {
   AWSSpokeAccountId: String
-  AWSAccountName: String
+  AWSSpokeAccountName: String
   Action: String
   AdminAction: String
   AvailabilityZone: String

--- a/source/ui/src/graphql/schema.graphql
+++ b/source/ui/src/graphql/schema.graphql
@@ -25,6 +25,7 @@ type TransitNetworkOrchestratorTableConnection {
 
 type TransitNetworkOrchestratorTableMoreFields {
   AWSSpokeAccountId: String
+  AWSAccountName: String
   Action: String
   AdminAction: String
   AvailabilityZone: String
@@ -46,6 +47,7 @@ type TransitNetworkOrchestratorTableMoreFields {
 
 type UpdateTransitNetworkOrchestratorTable {
   AWSSpokeAccountId: String
+  AWSAccountName: String
   Action: String
   AdminAction: String
   AvailabilityZone: String

--- a/source/ui/src/graphql/schema.json
+++ b/source/ui/src/graphql/schema.json
@@ -184,6 +184,17 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
+          "name" : "AWSAccountName",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } , {
           "name" : "Action",
           "description" : null,
           "args" : [ ],
@@ -607,6 +618,17 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
+          "name" : "AWSAccountName",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } , {
           "name" : "Action",
           "description" : null,
           "args" : [ ],

--- a/source/ui/src/graphql/schema.json
+++ b/source/ui/src/graphql/schema.json
@@ -184,7 +184,7 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "AWSAccountName",
+          "name" : "AWSSpokeAccountName",
           "description" : null,
           "args" : [ ],
           "type" : {
@@ -618,7 +618,7 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "AWSAccountName",
+          "name" : "AWSSpokeAccountName",
           "description" : null,
           "args" : [ ],
           "type" : {


### PR DESCRIPTION
*Description of changes:*

When STNO receives a VPC/Subnet attachment and if approval is required. it dispaches an email to the network admin and it shows certain information in the web interface. 

This information is missing the account name, and that makes it difficult for us to know where this request is coming from.

A few edits in the graphql schema, react and the stno state machine lambda should take care of that by calling Organisations().get_account_name on the passed spoke_account from the event.account. 

If this information does not exist, stno will save None in the Dynamo DB table and it won't show anything in the Spoke Account Name in the web interface.

Kodus to @weargoggles for the idea

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
